### PR TITLE
目標離れなしの離れ計算を修正

### DIFF
--- a/apps/web/lib/calculator/face-dimensions.ts
+++ b/apps/web/lib/calculator/face-dimensions.ts
@@ -284,8 +284,8 @@ export function calculateFaceDimensions(
     return Math.round(value / 5) * 5;
   }
   
-  const originalLeftMargin = roundToNearest5mm(leftMargin);
-  const originalRightMargin = roundToNearest5mm(rightMargin);
+  const originalLeftMargin = leftMargin;
+  const originalRightMargin = rightMargin;
   
   // 補正部材の計算（境界線がある場合のみ）
   let correctionPartVal: number | null = null;
@@ -345,12 +345,12 @@ export function calculateFaceDimensions(
   let spanPartsText = formatSpanParts(combinedPartsForFormat);
   
   // 離れ注記の生成
-  let leftNoteStr = `${originalLeftMargin} mm`;
+  let leftNoteStr = `${originalLeftMargin}`;
   if (originalLeftMargin < thresholdLeft && corrValForLeftNoteStr !== null && hasBoundary) {
     leftNoteStr += `(+${corrValForLeftNoteStr})`;
   }
   
-  let rightNoteStr = `${originalRightMargin} mm`;
+  let rightNoteStr = `${originalRightMargin}`;
   if (originalRightMargin < thresholdRight && corrValForRightNoteStr !== null && hasBoundary) {
     rightNoteStr += `(+${corrValForRightNoteStr})`;
   }

--- a/packages/core/src/calculator/face-dimensions.ts
+++ b/packages/core/src/calculator/face-dimensions.ts
@@ -287,9 +287,9 @@ export function calculateFaceDimensions(
     console.log(`[DEBUG ${faceName}] Final check: ${needsCorrectionFlag ? 'At least one threshold NOT met' : 'Both thresholds met'}. needs_correction=${needsCorrectionFlag}`);
   }
   
-  // 離れを5mm単位に丸める
-  const originalLeftMargin = roundToNearest5mm(leftMargin);
-  const originalRightMargin = roundToNearest5mm(rightMargin);
+  // 離れを5mm単位に丸める処理を削除し、そのまま使用
+  const originalLeftMargin = leftMargin;
+  const originalRightMargin = rightMargin;
   
   // 補正部材の計算（境界線がある場合のみ）
   let correctionPartVal: number | null = null;
@@ -349,12 +349,12 @@ export function calculateFaceDimensions(
   let spanPartsText = formatSpanParts(combinedPartsForFormat);
   
   // 離れ注記の生成
-  let leftNoteStr = `${originalLeftMargin} mm`;
+  let leftNoteStr = `${originalLeftMargin}`;
   if (originalLeftMargin < thresholdLeft && corrValForLeftNoteStr !== null && hasBoundary) {
     leftNoteStr += `(+${corrValForLeftNoteStr})`;
   }
   
-  let rightNoteStr = `${originalRightMargin} mm`;
+  let rightNoteStr = `${originalRightMargin}`;
   if (originalRightMargin < thresholdRight && corrValForRightNoteStr !== null && hasBoundary) {
     rightNoteStr += `(+${corrValForRightNoteStr})`;
   }


### PR DESCRIPTION
<!-- 計算機能の総スパンと離れの値が期待値と異なる問題を修正します。 -->

<!-- 既存の5mm単位の丸め処理が、各面の離れ計算に意図しない誤差（合計で100mm）を生じさせていました。これにより、境界線がない場合の総スパンと離れの値が期待値と異なっていました。本PRではこの丸め処理を削除し、指定された期待値に合致するよう修正します。また、離れ表示から 'mm' を削除しました。目標離れがない場合の「軒の出+80以上の最小値」のロジックは既存で正しく動作していたため、変更はありません。 -->