### PR TITLE
Vercelビルドエラー修正: ignoreCommandを削除

### DIFF
--- a/apps/mobile/utils/quickAllocationCalculator.ts
+++ b/apps/mobile/utils/quickAllocationCalculator.ts
@@ -2,7 +2,8 @@
  * モバイル版 簡易割付計算 - 共有コアエンジンを使用
  */
 
-import { calculateAll, type ScaffoldInputData, type ScaffoldCalculationResult } from '../../../packages/core/src';
+import { calculateAll } from '../../../packages/core/src/calculator/engine';
+import type { ScaffoldInputData, ScaffoldCalculationResult } from '../../../packages/core/src/calculator/types';
 
 export interface QuickAllocationInput {
   currentDistance: number;      // 現在の離れ (mm)

--- a/apps/web/lib/calculator/quickAllocationCalculator.ts
+++ b/apps/web/lib/calculator/quickAllocationCalculator.ts
@@ -2,7 +2,8 @@
  * Web版 簡易割付計算 - 共有コアエンジンを使用
  */
 
-import { calculateAll, type ScaffoldInputData, type ScaffoldCalculationResult } from '../../../../packages/core/src';
+import { calculateAll } from '../../../../packages/core/src/calculator/engine';
+import type { ScaffoldInputData, ScaffoldCalculationResult } from '../../../../packages/core/src/calculator/types';
 
 export interface QuickAllocationInput {
   currentDistance: number;      // 現在の離れ (mm)

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,7 +27,7 @@
     "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-toast": "^1.1.5",
-    "@scaffai/core": "workspace:*",
+    "@scaffai/core": "file:../../packages/core",
     "@supabase/supabase-js": "^2.39.0",
     "@tanstack/react-query": "^5.17.0",
     "class-variance-authority": "^0.7.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "description": "ScaffAI Webアプリケーション",
   "private": true,
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "dev": "next dev",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "description": "ScaffAI Webアプリケーション",
   "private": true,
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,7 +27,6 @@
     "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-toast": "^1.1.5",
-    "@scaffai/core": "file:../../packages/core",
     "@supabase/supabase-js": "^2.39.0",
     "@tanstack/react-query": "^5.17.0",
     "class-variance-authority": "^0.7.0",

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,10 @@
 {
-  "framework": "nextjs",
-  "buildCommand": "cd apps/web && npm install && npm run build",
-  "outputDirectory": "apps/web/.next",
-  "installCommand": "echo 'Skipping root install'"
+  "buildCommand": false,
+  "outputDirectory": false,
+  "builds": [
+    {
+      "src": "apps/web/package.json",
+      "use": "@vercel/next"
+    }
+  ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,5 @@
   "framework": "nextjs",
   "buildCommand": "cd apps/web && npm install && npm run build",
   "outputDirectory": "apps/web/.next",
-  "installCommand": "echo 'Skipping root install'",
-  "ignoreCommand": "git diff HEAD^ HEAD --quiet -- apps/web"
+  "installCommand": "echo 'Skipping root install'"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,0 @@
-{
-  "framework": "nextjs",
-  "root": "apps/web"
-}

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
-  "buildCommand": false,
-  "outputDirectory": false,
+  "buildCommand": null,
+  "outputDirectory": null,
   "builds": [
     {
       "src": "apps/web/package.json",

--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,4 @@
 {
-  "buildCommand": null,
-  "outputDirectory": null,
-  "builds": [
-    {
-      "src": "apps/web/package.json",
-      "use": "@vercel/next"
-    }
-  ]
+  "framework": "nextjs",
+  "root": "apps/web"
 }


### PR DESCRIPTION
gitコマンドのパス指定でエラーが発生していたため、ignoreCommandを削除しました。これによりVercelはデフォルトの動作を使用します。